### PR TITLE
Bug(EJ2-844972): Resolved the floatLabelType issue in docs

### DIFF
--- a/ej2-javascript/code-snippet/dropdownlist/asterisk-cs1/index.ts
+++ b/ej2-javascript/code-snippet/dropdownlist/asterisk-cs1/index.ts
@@ -10,9 +10,8 @@ let dropDownListObject: DropDownList = new DropDownList({
     //set the data to dataSource property
     dataSource: sportsData,
     // set placeholder to DropDownList input element
-    placeholder: "Select a game"
-
-    floatLabelType: "auto"
+    placeholder: "Select a game",
+    floatLabelType: "Auto"
 });
 
 // render initialized DropDownList


### PR DESCRIPTION
corrected the spelling mistake for the floatlabel binding value in the Javascript dropdownlist.
https://ej2.syncfusion.com/documentation/drop-down-list/style?cs-save-lang=1&cs-lang=ts#adding-mandatory-asterisk-to-placeholder-and-float-label